### PR TITLE
fix: use latest code from help-docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,19 @@ const Entities = require('html-entities').XmlEntities
 const entities = new Entities()
 const stripHtmlComments = require('strip-html-comments')
 
-// used below to remove unwanted newlines
-const inlineTags = '(?:a|code|em)'
-const inlineTagRegex = new RegExp(`\n?(</?${inlineTags}>?)\n?`, 'gm')
+// used below to remove extra newlines in TOC lists
+const endLine = '</a>\n'
+const blankLine = '\\s*?\n*?'
+const startNextLine = '[^\\S\n]*?[-\\*] <a'
+const blankLineInList = new RegExp(
+  `(${endLine})${blankLine}(${startNextLine})`,
+  'mg'
+)
+
+// used below to remove unwanted newlines from inline tags in tables
+const inlineTags = ['a', 'code', 'em']
+const inlineTagString = `(?:${inlineTags.join('|')})`
+const inlineTagRegex = new RegExp(`\n?(</?${inlineTagString}>?)\n?`, 'gm')
 
 // parse multiple times because some templates contain more templates. :]
 module.exports = async function renderContent (
@@ -22,7 +32,10 @@ module.exports = async function renderContent (
   options = {}
 ) {
   try {
-    if (template) template = stripHtmlComments(template)
+    // remove any newlines that precede html comments, then remove the comments
+    if (template) {
+      template = stripHtmlComments(template.replace(/\n<!--/g, '<!--'))
+    }
 
     template = whitespaceControl(template)
 
@@ -55,6 +68,15 @@ module.exports = async function renderContent (
       '<pre><code class="hljs language-shell">$1</code></pre>'
     )
 
+    // clean up empty lines in TOC lists left by unrendered list items (due to productVersions)
+    // for example, remove the blank line here:
+    //    - <a>foo</a>
+    //
+    //    - <a>bar</a>
+    if (template.includes('</a>')) {
+      template = template.replace(blankLineInList, '$1$2')
+    }
+
     // this removes any extra newlines left by (now resolved) liquid
     // statements so that extra space doesn't mess with list numbering
     template = template.replace(/\n\n\n/g, '\n\n')
@@ -62,7 +84,7 @@ module.exports = async function renderContent (
     let { content: html } = await hubdown(template)
 
     // Remove unwanted newlines (which appear as spaces) from inline tags inside tables
-    html = html.replace(inlineTagRegex, '$1')
+    if (html.includes('<table>')) html = removeNewlinesFromInlineTags(html)
 
     if (options.textOnly) {
       html = cheerio
@@ -80,6 +102,24 @@ module.exports = async function renderContent (
     }
     throw error
   }
+}
+
+function removeNewlinesFromInlineTags (html) {
+  const $ = cheerio.load(html, { xmlMode: true })
+
+  // see https://cheerio.js.org/#html-htmlstring-
+  $(inlineTags.join(','))
+    .parents('td')
+    .get()
+    .map(tag =>
+      $(tag).html(
+        $(tag)
+          .html()
+          .replace(inlineTagRegex, '$1')
+      )
+    )
+
+  return $.html()
 }
 
 Object.assign(module.exports, {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/docs/render-content",
   "license": "MIT",
   "scripts": {
+    "lint": "standard --fix && prettier-standard --format '**/*.js'",
     "test": "prettier-standard '**/*.js' && standard && tap test/*.js && npm run test:deps",
     "test:deps": "dependency-check . --missing --no-dev && dependency-check . --unused --no-dev"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/docs/render-content",
   "license": "MIT",
   "scripts": {
-    "lint": "standard --fix && prettier-standard --format '**/*.js'",
+    "lint": "standard --fix && prettier-standard",
     "test": "prettier-standard '**/*.js' && standard && tap test/*.js && npm run test:deps",
     "test:deps": "dependency-check . --missing --no-dev && dependency-check . --unused --no-dev"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "standard --fix && prettier-standard",
-    "test": "prettier-standard '**/*.js' && standard && tap test/*.js && npm run test:deps",
+    "test": "npm run lint && tap test/*.js && npm run test:deps",
     "test:deps": "dependency-check . --missing --no-dev && dependency-check . --unused --no-dev"
   },
   "dependencies": {


### PR DESCRIPTION
The original version of this module that lives in the help-docs repo has changed a bit since this repo was created. This PR brings in those latest changes (and adds an `npm run lint` task).

cc @sarahs @juliangruber