### PR TITLE
fix: remove workaround for malformed markup

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,10 +65,6 @@ module.exports = async function renderContent (
       '<pre><code class="hljs language-shell">$1</code></pre>'
     )
 
-    // work around hubdown bug where # lines in pre blocks get turned into H1s
-    // see https://github.com/docs/render-content/issues/7
-    template = template.replace(/#/g, '&#x23;')
-
     // clean up empty lines in TOC lists left by unrendered list items (due to productVersions)
     // for example, remove the blank line here:
     //    - <a>foo</a>

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -183,8 +183,8 @@ test('renderContent', async t => {
     const template = `
 1. This is a list item with code containing a comment:
   \`\`\`shell
-$ foo the bar
-# some comment here
+  $ foo the bar
+  # some comment here
   \`\`\`
 1. This is another list item.
     `
@@ -194,5 +194,46 @@ $ foo the bar
     t.ok($.html().includes('# some comment here'))
     t.notOk($.html().includes('<h1 id="some-comment-here">'))
     t.notOk($.html().includes('<a href="#some-comment-here">'))
+  })
+
+  await t.test('renders headings at the right level', async t => {
+    const template = `
+# This is a level one
+
+## This is a level two
+
+### This is a level three
+
+#### This is a level four
+
+##### This is a level five
+`
+    const html = await renderContent(template)
+    const $ = cheerio.load(html, { xmlMode: true })
+    t.ok(
+      $.html().includes(
+        '<h1 id="this-is-a-level-one"><a href="#this-is-a-level-one">This is a level one</a></h1>'
+      )
+    )
+    t.ok(
+      $.html().includes(
+        '<h2 id="this-is-a-level-two"><a href="#this-is-a-level-two">This is a level two</a></h2>'
+      )
+    )
+    t.ok(
+      $.html().includes(
+        '<h3 id="this-is-a-level-three"><a href="#this-is-a-level-three">This is a level three</a></h3>'
+      )
+    )
+    t.ok(
+      $.html().includes(
+        '<h4 id="this-is-a-level-four"><a href="#this-is-a-level-four">This is a level four</a></h4>'
+      )
+    )
+    t.ok(
+      $.html().includes(
+        '<h5 id="this-is-a-level-five"><a href="#this-is-a-level-five">This is a level five</a></h5>'
+      )
+    )
   })
 })


### PR DESCRIPTION
This PR removes the workaround added in https://github.com/docs/render-content/pull/16/commits/52f42b686455b0f612e2af71c9325c726d32f471#diff-168726dbe96b3ce427e7fedce31bb0bcR70.

That workaround was intended to support code blocks like this:
<pre>1. This is a list item with code containing a comment:
  ```shell
$ foo the bar
# some comment here
  ```
1. This is another list item.</pre>

But the workaround was not properly scoped to code blocks and messed with heading rendering. 

Instead, it will be better to fix the indentation in the code blocks in the source, like this:
<pre>1. This is a list item with code containing a comment:
  ```shell
  $ foo the bar
  # some comment here
  ```
1. This is another list item.</pre>

☝️ `hubdown` will render this correctly without any workaround needed.

/cc @zeke 