### PR TITLE
fix: typo inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The [Liquid](https://ghub.io/liquid) instance used internally.
 
 ### .liquidOcticons(string)
 
-Render [`Octicons`](https://ghubio/@primer/octicons) in `string`. Returns a `String`.
+Render [`Octicons`](https://ghub.io/@primer/octicons) in `string`. Returns a `String`.
 
 Examples:
 


### PR DESCRIPTION
### Why 
There is a broken link inside `README.md` for Octicons. 

### What
Fixed link to [`Octicons`](https://ghub.io/@primer/octicons). I know it's not a lot, but a small contribution before my internship starts 😊 