### PR TITLE
feat: update Octicons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -284,9 +284,9 @@
       }
     },
     "@primer/octicons": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.1.1.tgz",
-      "integrity": "sha512-7EGM0+Kx39bIgaYr9bTCzFvBCxm+fqh/YJIoSns8zfCwss32ZJ2GDP3024UH709VQtM5cKFU4JcIYPHyGdSfIg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.6.0.tgz",
+      "integrity": "sha512-B5Wzk5izRXXz0JqEXJkVUtqhCXSpUKgqYkVwegMkp5sziBW+ksd9LPbONlCWyyLODwf9GsI2sBXekR7m+JJDBw==",
       "requires": {
         "object-assign": "^4.1.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,9 +284,9 @@
       }
     },
     "@primer/octicons": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.6.0.tgz",
-      "integrity": "sha512-B5Wzk5izRXXz0JqEXJkVUtqhCXSpUKgqYkVwegMkp5sziBW+ksd9LPbONlCWyyLODwf9GsI2sBXekR7m+JJDBw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-10.0.0.tgz",
+      "integrity": "sha512-iuQubq62zXZjPmaqrsfsCZUqIJgZhmA6W0tKzIKGRbkoLnff4TFFCL87hfIRATZ5qZPM4m8ioT8/bXI7WVa9WQ==",
       "requires": {
         "object-assign": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:deps": "dependency-check . --missing --no-dev && dependency-check . --unused --no-dev"
   },
   "dependencies": {
-    "@primer/octicons": "^9.6.0",
+    "@primer/octicons": "^10.0.0",
     "cheerio": "^1.0.0-rc.3",
     "html-entities": "^1.2.1",
     "hubdown": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:deps": "dependency-check . --missing --no-dev && dependency-check . --unused --no-dev"
   },
   "dependencies": {
-    "@primer/octicons": "^9.1.1",
+    "@primer/octicons": "^9.6.0",
     "cheerio": "^1.0.0-rc.3",
     "html-entities": "^1.2.1",
     "hubdown": "^2.5.0",

--- a/test/liquid-octicons.test.js
+++ b/test/liquid-octicons.test.js
@@ -10,6 +10,12 @@ test('liquid octicons', async t => {
     t.ok(/svg/.test(output))
   })
 
+  await t.test('renders newly added octicons', async t => {
+    const template = '{{ octicon-north-star The North Star icon }}'
+    const output = liquidOcticons(template)
+    t.ok(/svg/.test(output))
+  })
+
   await t.test('renders liquid octicons with optional color', async t => {
     const template =
       '{{ octicon-diff-removed The diff removed icon color-red }}'


### PR DESCRIPTION
Docs writers want to use a new Octicon, `{{ octicon-north-star The North Star icon }}`, but it's rendering as `undefined`. 

This PR updates the `@primer/octicons` package so we get access to the latest and greatest Octicons.

/cc @zeke 