### PR TITLE
fix: Disable automatic syntax highlighting language guessing

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,10 @@ module.exports = async function renderContent (
     // statements so that extra space doesn't mess with list numbering
     template = template.replace(/\n\n\n/g, '\n\n')
 
-    let { content: html } = await hubdown(template)
+    let { content: html } = await hubdown(template, {
+      // Disable automatic language guessing in syntax highlighting
+      highlight: { subset: false }
+    })
 
     // Remove unwanted newlines (which appear as spaces) from inline tags inside tables
     if (html.includes('<table>')) html = removeNewlinesFromInlineTags(html)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3240,9 +3240,9 @@
       }
     },
     "hast-util-to-string": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.3.tgz",
-      "integrity": "sha512-3lDgDE5OdpTfP3aFeKRWEwdIZ4vprztvp+AoD+RhF7uGOBs1yBDWZFadxnjcUV4KCoI3vB9A7gdFO98hEXA90w=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz",
+      "integrity": "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w=="
     },
     "hast-util-to-text": {
       "version": "1.0.1",
@@ -3271,9 +3271,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.16.2.tgz",
-      "integrity": "sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
+      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg=="
     },
     "highlightjs-graphql": {
       "version": "1.0.1",
@@ -3348,9 +3348,9 @@
       }
     },
     "hubdown": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hubdown/-/hubdown-2.5.0.tgz",
-      "integrity": "sha512-HuF5774apmrskvXmOwOmBADqSpziJV7QBBp6S5F+Fs09RL49EEz6qh2sPHUEKERN/atjnlYbQI+SLUFcz2cZ2Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hubdown/-/hubdown-2.6.0.tgz",
+      "integrity": "sha512-gqC4TfGK/gEuAElYRZh4HUEz+TCM4BZ6NQZkNOvWurhQu+PwaF6PVPPTb9DN1h1DUn/kEsFL37XsUJPnJWae+Q==",
       "requires": {
         "gray-matter": "^3.0.7",
         "hasha": "^3.0.0",
@@ -4086,12 +4086,12 @@
       }
     },
     "lowlight": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.13.1.tgz",
-      "integrity": "sha512-kQ71/T6RksEVz9AlPq07/2m+SU/1kGvt9k39UtvHX760u4SaWakaYH7hYgH5n6sTsCWk4MVYzUzLU59aN5CSmQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.14.0.tgz",
+      "integrity": "sha512-N2E7zTM7r1CwbzwspPxJvmjAbxljCPThTFawEX2Z7+P3NGrrvY54u8kyU16IY4qWfoVIxY8SYCS8jTkuG7TqYA==",
       "requires": {
         "fault": "^1.0.0",
-        "highlight.js": "~9.16.0"
+        "highlight.js": "~10.1.0"
       }
     },
     "lru-cache": {
@@ -11803,9 +11803,9 @@
       }
     },
     "vfile": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
-      "integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+      "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@primer/octicons": "^10.0.0",
     "cheerio": "^1.0.0-rc.3",
     "html-entities": "^1.2.1",
-    "hubdown": "^2.5.0",
+    "hubdown": "^2.6.0",
     "liquid": "^4.0.1",
     "semver": "^5.7.1",
     "strip-html-comments": "^1.0.0"

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -235,5 +235,17 @@ test('renderContent', async t => {
         '<h5 id="this-is-a-level-five"><a href="#this-is-a-level-five">This is a level five</a></h5>'
       )
     )
+
+    await t.only('does not autoguess code block language', async t => {
+      const template = `
+\`\`\`
+some code
+\`\`\`\
+      `
+      const html = await renderContent(template)
+      const $ = cheerio.load(html, { xmlMode: true })
+      console.log($.html())
+      t.ok($.html().includes('<pre><code class="hljs">'))
+    })
   })
 })

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -235,17 +235,27 @@ test('renderContent', async t => {
         '<h5 id="this-is-a-level-five"><a href="#this-is-a-level-five">This is a level five</a></h5>'
       )
     )
+  })
 
-    await t.only('does not autoguess code block language', async t => {
-      const template = `
+  await t.test('does syntax highlighting', async t => {
+    const template = `
+\`\`\`js
+const example = true
+\`\`\`\`
+    `
+    const html = await renderContent(template)
+    const $ = cheerio.load(html, { xmlMode: true })
+    t.ok($.html().includes('<pre><code class="hljs language-js">'))
+  })
+
+  await t.test('does not autoguess code block language', async t => {
+    const template = `
 \`\`\`
 some code
 \`\`\`\
-      `
-      const html = await renderContent(template)
-      const $ = cheerio.load(html, { xmlMode: true })
-      console.log($.html())
-      t.ok($.html().includes('<pre><code class="hljs">'))
-    })
+    `
+    const html = await renderContent(template)
+    const $ = cheerio.load(html, { xmlMode: true })
+    t.ok($.html().includes('<pre><code>some code\n</code></pre>'))
   })
 })


### PR DESCRIPTION
Described in https://github.com/github/help-docs/issues/13673, [`hubdown`](https://github.com/electron/hubdown) -> [`rehype-highlight`](https://github.com/rehypejs/rehype-highlight/) -> [`lowlight`](https://github.com/wooorm/lowlight) has a feature to guess the language of a code block if none was provided:

```
~~~
const test = 'hello-world-docker-action'
~~~
```

Unfortunately, it's wrong a lot - that above code example is considered `ini` instead of JavaScript as one would expect. So this PR adds the `subset: false` option to `hubdown`, which is passed to `rehype-highlight`, which uses `lowlight.highlight` instead of `lowlight.highlightAuto`:

https://github.com/rehypejs/rehype-highlight/blob/66d5d9b8fa19d04e3ca3dbad13a32ef74fe23679/index.js#L69-L78

Let me know if this is intentional. I'd opt for removing the guessing, no syntax highlighting is better than incorrect syntax highlighting to me!