### PR TITLE
fix: add Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [10.x, 12.x]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ const entities = new Entities()
 const stripHtmlComments = require('strip-html-comments')
 
 // used below to remove extra newlines in TOC lists
-const endLine = '</a>\n'
-const blankLine = '\\s*?\n*?'
-const startNextLine = '[^\\S\n]*?[-\\*] <a'
+const endLine = '</a>\r?\n'
+const blankLine = '\\s*?\[\r\n]*'
+const startNextLine = '[^\\S\r\n]*?[-\\*] <a'
 const blankLineInList = new RegExp(
   `(${endLine})${blankLine}(${startNextLine})`,
   'mg'
@@ -76,7 +76,7 @@ module.exports = async function renderContent (
 
     // this removes any extra newlines left by (now resolved) liquid
     // statements so that extra space doesn't mess with list numbering
-    template = template.replace(/\n\n\n/g, '\n\n')
+    template = template.replace(/(\r?\n){3}/g, '\n\n')
 
     let { content: html } = await hubdown(template, {
       // Disable automatic language guessing in syntax highlighting

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const stripHtmlComments = require('strip-html-comments')
 
 // used below to remove extra newlines in TOC lists
 const endLine = '</a>\r?\n'
-const blankLine = '\\s*?\[\r\n]*'
+const blankLine = '\\s*?[\r\n]*'
 const startNextLine = '[^\\S\r\n]*?[-\\*] <a'
 const blankLineInList = new RegExp(
   `(${endLine})${blankLine}(${startNextLine})`,

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = async function renderContent (
 
     // this workaround loses syntax highlighting but correctly handles tags like <em> and entities like &lt;
     template = template.replace(
-      /``` ?shell\n\s*?(\S[\s\S]*?)\n.*?```/gm,
+      /``` ?shell\r?\n\s*?(\S[\s\S]*?)\r?\n.*?```/gm,
       '<pre><code class="hljs language-shell">$1</code></pre>'
     )
 

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -3,6 +3,11 @@
 const cheerio = require('cheerio')
 const renderContent = require('..')
 const { test } = require('tap')
+const { EOL } = require('os')
+
+// Use platform specific line endings for realistic tests when templates have
+// been loaded from disk
+const nl = str => str.replace(/\n/g, EOL)
 
 test('renderContent', async t => {
   await t.test(
@@ -16,9 +21,9 @@ test('renderContent', async t => {
   )
 
   await t.test('preserves content within {% raw %} tags', async t => {
-    const template = `
+    const template = nl(`
       For example: {% raw %}{% include cool_header.html %}{% endraw %}.
-    `
+    `)
     const expected = '<p>For example: {% include cool_header.html %}.</p>'
     const output = await renderContent(template)
     t.equal(output, expected)
@@ -41,9 +46,9 @@ test('renderContent', async t => {
           }
         }
       }
-      const template = `
+      const template = nl(`
       For example: {{ site.data.reusables.fake_reusable_file.foo }}.
-    `
+    `)
       const expected = '<p>For example: {% include cool_header.html %}.</p>'
       const context = site.en
       const output = await renderContent(template, context)
@@ -55,29 +60,12 @@ test('renderContent', async t => {
   await t.test(
     'removes extra newlines to prevent lists from breaking',
     async t => {
-      const template = `
+      const template = nl(`
 1. item one
 1. item two
 
 
-1. item three`
-
-      const html = await renderContent(template)
-      const $ = cheerio.load(html, { xmlMode: true })
-      t.equal($('ol').length, 1)
-      t.equal($('ol > li').length, 3)
-    }
-  )
-
-  await t.test(
-    'supports windows line endings',
-    async t => {
-      const template = '\r\n' +
-        '1. item one\r\n' +
-        '1. item two\r\n' +
-        '\r\n' +
-        '\r\n' +
-        '1. item three'
+1. item three`)
 
       const html = await renderContent(template)
       const $ = cheerio.load(html, { xmlMode: true })
@@ -87,19 +75,9 @@ test('renderContent', async t => {
   )
 
   await t.test('removes extra newlines from lists of links', async t => {
-    const template = `- <a>item</a>
+    const template = nl(`- <a>item</a>
 
-- <a>item</a>`
-
-    const html = await renderContent(template)
-    const $ = cheerio.load(html, { xmlMode: true })
-    t.equal($('ul p').length, 0)
-  })
-
-  await t.test('supports windows line endings', async t => {
-    const template = '- <a>item</a>\r\n' +
-      '\r\n' +
-      '- <a>item</a>'
+- <a>item</a>`)
 
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
@@ -172,12 +150,12 @@ test('renderContent', async t => {
   })
 
   await t.test('does not render newlines around links in tables', async t => {
-    const template = `
+    const template = nl(`
     | Keyboard shortcut | Description
     |-----------|------------
     |<kbd>g</kbd> <kbd>c</kbd> | Go to the **Code** tab
     |<kbd>g</kbd> <kbd>i</kbd> | Go to the **Issues** tab. For more information, see "[About issues](/articles/about-issues)."
-    `
+    `)
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
     t.ok(
@@ -190,11 +168,11 @@ test('renderContent', async t => {
   await t.test(
     'does not render newlines around inline code in tables',
     async t => {
-      const template = `
+      const template = nl(`
     | Package manager | formats |
     | --- | --- |
     | Python | \`requirements.txt\`, \`pipfile.lock\`
-    `
+    `)
       const html = await renderContent(template)
       const $ = cheerio.load(html, { xmlMode: true })
       t.ok(
@@ -206,25 +184,25 @@ test('renderContent', async t => {
   )
 
   await t.test('does not render newlines around emphasis in code', async t => {
-    const template = `
+    const template = nl(`
     | Qualifier        | Example
     | ------------- | -------------
     | <code>user:<em>USERNAME</em></code> | [**user:defunkt ubuntu**](https://github.com/search?q=user%3Adefunkt+ubuntu&type=Issues) matches issues with the word "ubuntu" from repositories owned by @defunkt.
-    `
+    `)
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
     t.ok($.html().includes('<code>user:<em>USERNAME</em></code>'))
   })
 
   await t.test('renders code blocks with # comments', async t => {
-    const template = `
+    const template = nl(`
 1. This is a list item with code containing a comment:
   \`\`\`shell
   $ foo the bar
   # some comment here
   \`\`\`
 1. This is another list item.
-    `
+    `)
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
     t.equal($('ol').length, 1)
@@ -234,7 +212,7 @@ test('renderContent', async t => {
   })
 
   await t.test('renders headings at the right level', async t => {
-    const template = `
+    const template = nl(`
 # This is a level one
 
 ## This is a level two
@@ -244,7 +222,7 @@ test('renderContent', async t => {
 #### This is a level four
 
 ##### This is a level five
-`
+`)
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
     t.ok(
@@ -275,22 +253,22 @@ test('renderContent', async t => {
   })
 
   await t.test('does syntax highlighting', async t => {
-    const template = `
+    const template = nl(`
 \`\`\`js
 const example = true
 \`\`\`\`
-    `
+    `)
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
     t.ok($.html().includes('<pre><code class="hljs language-js">'))
   })
 
   await t.test('does not autoguess code block language', async t => {
-    const template = `
+    const template = nl(`
 \`\`\`
 some code
 \`\`\`\
-    `
+    `)
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
     t.ok($.html().includes('<pre><code>some code\n</code></pre>'))

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -69,11 +69,11 @@ test('renderContent', async t => {
     }
   )
 
-  await t.test("doesn't add paragraphs to lists with newlines", async t => {
+  await t.test('removes extra newlines from lists of links', async t => {
     const template = `
-1. item one
+1. [item one](#)
 
-1. item two`
+1. [item two](#)`
 
     const html = await renderContent(template)
     console.log(html)

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -71,9 +71,10 @@ test('renderContent', async t => {
 
   await t.test('removes extra newlines from lists of links', async t => {
     const template = `
-1. [item one](#)
+- <a>item one</a>
 
-1. [item two](#)`
+
+- <a>item two</a>`
 
     const html = await renderContent(template)
     console.log(html)

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -77,7 +77,6 @@ test('renderContent', async t => {
 - <a>item two</a>`
 
     const html = await renderContent(template)
-    console.log(html)
     const $ = cheerio.load(html, { xmlMode: true })
     t.equal($('ol p').length, 0)
   })

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -69,6 +69,18 @@ test('renderContent', async t => {
     }
   )
 
+  await t.test("doesn't add paragraphs to lists with newlines", async t => {
+    const template = `
+1. item one
+
+1. item two`
+
+    const html = await renderContent(template)
+    console.log(html)
+    const $ = cheerio.load(html, { xmlMode: true })
+    t.equal($('ol p').length, 0)
+  })
+
   await t.test('renders text only', async t => {
     const template = 'my favorite color is {{ color }}.'
     const context = { color: 'orange' }

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -69,16 +69,42 @@ test('renderContent', async t => {
     }
   )
 
+  await t.test(
+    'supports windows line endings',
+    async t => {
+      const template = '\r\n' +
+        '1. item one\r\n' +
+        '1. item two\r\n' +
+        '\r\n' +
+        '\r\n' +
+        '1. item three'
+
+      const html = await renderContent(template)
+      console.log({ html  })
+      const $ = cheerio.load(html, { xmlMode: true })
+      t.equal($('ol').length, 1)
+      t.equal($('ol > li').length, 3)
+    }
+  )
+
   await t.test('removes extra newlines from lists of links', async t => {
-    const template = `
-- <a>item one</a>
+    const template = `- <a>item</a>
 
-
-- <a>item two</a>`
+- <a>item</a>`
 
     const html = await renderContent(template)
     const $ = cheerio.load(html, { xmlMode: true })
-    t.equal($('ol p').length, 0)
+    t.equal($('ul p').length, 0)
+  })
+
+  await t.test('supports windows line endings', async t => {
+    const template = '- <a>item</a>\r\n' +
+      '\r\n' +
+      '- <a>item</a>'
+
+    const html = await renderContent(template)
+    const $ = cheerio.load(html, { xmlMode: true })
+    t.equal($('ul p').length, 0)
   })
 
   await t.test('renders text only', async t => {

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -80,7 +80,6 @@ test('renderContent', async t => {
         '1. item three'
 
       const html = await renderContent(template)
-      console.log({ html  })
       const $ = cheerio.load(html, { xmlMode: true })
       t.equal($('ol').length, 1)
       t.equal($('ol > li').length, 3)

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -5,7 +5,7 @@ const renderContent = require('..')
 const { test } = require('tap')
 const { EOL } = require('os')
 
-// Use platform specific line endings for realistic tests when templates have
+// Use platform-specific line endings for realistic tests when templates have
 // been loaded from disk
 const nl = str => str.replace(/\n/g, EOL)
 


### PR DESCRIPTION
A few line ending ending related Windows bugs have been fixed, and the test suite was extended to always use OS specific line endings.

TIL:

```js
const str = `
hi
`
str === '\nhi\n'
```

No matter what the OS is, template literals will always have unix style line endings.