### PR TITLE
chore: Run CI on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Node CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - $default
 
 jobs:
   build:


### PR DESCRIPTION
This updates our `test.yml` workflow to run CI on `pull_request`, which will run on PRs from forks. I've also made it only run on `push` to the default branch, since we don't need it to run on a push to a PR too.