### PR TITLE
fix: Line breaks in <td> issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = async function renderContent (
 }
 
 function removeNewlinesFromInlineTags (html) {
-  const $ = cheerio.load(html, { xmlMode: true })
+  const $ = cheerio.load(html)
 
   // see https://cheerio.js.org/#html-htmlstring-
   $(inlineTags.join(','))
@@ -119,7 +119,7 @@ function removeNewlinesFromInlineTags (html) {
       )
     )
 
-  return $.html()
+  return $('body').html()
 }
 
 Object.assign(module.exports, {

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -273,4 +273,15 @@ some code
     const $ = cheerio.load(html, { xmlMode: true })
     t.ok($.html().includes('<pre><code>some code\n</code></pre>'))
   })
+
+  await t.test('renders a line break in a table', async t => {
+    const content = `| Webhook event payload | Activity types |
+| --------------------- | -------------- |
+| [\`issues\`](/webhooks/event-payloads/#issues) | - \`opened\`<br/>- \`edited\`<br/>- \`other\` |`
+    const file = await renderContent(content)
+    t.equal(
+      file,
+      '<table><thead><tr><th>Webhook event payload</th><th>Activity types</th></tr></thead><tbody><tr><td><a href="/webhooks/event-payloads/#issues"><code>issues</code></a></td><td>- <code>opened</code><br>- <code>edited</code><br>- <code>other</code></td></tr></tbody></table>'
+    )
+  })
 })


### PR DESCRIPTION
We noticed an issue where `<br>` tags duplicate when inside `<td>` elements.