### PR TITLE
chore: Upgrade to liquid@v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3978,8 +3978,9 @@
       "dev": true
     },
     "liquid": {
-      "version": "github:docs/liquid#c92ae7f1452a4ea7afb9c53d55c231ec1f05ef27",
-      "from": "github:docs/liquid#more-modern-js",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/liquid/-/liquid-5.0.0.tgz",
+      "integrity": "sha512-lpoE6D+nLSn4W0SwdV1B2EWX+DXFeroSAFk29+XLyO9Y+/k9yRZ4SyoGQCcAHw9kt/G6D/nJaHlStZbbknpsUg==",
       "requires": {
         "strftime": "~0.9.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3978,9 +3978,8 @@
       "dev": true
     },
     "liquid": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/liquid/-/liquid-4.0.1.tgz",
-      "integrity": "sha512-V6udjBJ/EHg3ShOm6+tIkKn0Oi1ajyJ0gN9ghgIU9d/zpzNsEEZazbsLlpHecjbSB/A2Zi2aCnMNZPJNOjAMOw==",
+      "version": "github:docs/liquid#071c4eef7e0a0eda509f1b3e46277cd1f1695644",
+      "from": "github:docs/liquid#more-modern-js",
       "requires": {
         "strftime": "~0.9.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3978,7 +3978,7 @@
       "dev": true
     },
     "liquid": {
-      "version": "github:docs/liquid#071c4eef7e0a0eda509f1b3e46277cd1f1695644",
+      "version": "github:docs/liquid#c92ae7f1452a4ea7afb9c53d55c231ec1f05ef27",
       "from": "github:docs/liquid#more-modern-js",
       "requires": {
         "strftime": "~0.9.2"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cheerio": "^1.0.0-rc.3",
     "html-entities": "^1.2.1",
     "hubdown": "^2.6.0",
-    "liquid": "^4.0.1",
+    "liquid": "github:docs/liquid#more-modern-js",
     "semver": "^5.7.1",
     "strip-html-comments": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cheerio": "^1.0.0-rc.3",
     "html-entities": "^1.2.1",
     "hubdown": "^2.6.0",
-    "liquid": "github:docs/liquid#more-modern-js",
+    "liquid": "^5.0.0",
     "semver": "^5.7.1",
     "strip-html-comments": "^1.0.0"
   },


### PR DESCRIPTION
This updates the library to use [liquid@v5](https://github.com/docs/liquid/releases/tag/v5.0.0), which rewrote the Liquid library to use modern JS instead of the output of Coffeescript. There shouldn't be any external-facing API changes.

I've marked this as `chore` but would not be opposed to forcing it to be a breaking change if we think that makes sense!