### PR TITLE
feat: Add a header w/ copy button to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,37 +46,19 @@ Options:
 
 The [Liquid](https://ghub.io/liquid) instance used internally.
 
-### .extendMarkdown(string)
+### Code block headers
 
-Extend the following markdown tags:
+You can add a header to code blocks by adding the `{:copy}` annotation after the code fences:
 
-- `mac`
-- `windows`
-- `linux`
-- `all`
-- `tip` (with extra styling)
-- `note` (with extra styling)
-- `warning` (with extra styling)
-- `danger` (with extra styling)
+    ```js{:copy}
+    const copyMe = true
+    ```
 
-From
+This renders:
 
+![image](https://user-images.githubusercontent.com/10660468/95881747-e96c6900-0d46-11eb-9abf-1e8ad16c7646.png)
 
-```md
-{{#TAG}}
-content
-{{/TAG}}
-```
-
-To
-
-```html
-<div class="extended-markdown TAG EXTRA_STYLING">
-content
-</div>
-```
-
-Returns a `String`.
+The un-highlighted text is available as `button.js-btn-copy`'s `data-clipboard-text` attribute.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const liquid = require('./liquid')
 const codeHeader = require('./plugins/code-header')
 const hubdown = require('hubdown')
+const remarkCodeExtra = require('remark-code-extra')
 const cheerio = require('cheerio')
 const Entities = require('html-entities').XmlEntities
 const entities = new Entities()
@@ -58,7 +59,9 @@ module.exports = async function renderContent (
     let { content: html } = await hubdown(template, {
       // Disable automatic language guessing in syntax highlighting
       highlight: { subset: false },
-      runBefore: [codeHeader]
+      runBefore: [[
+        remarkCodeExtra, { transform: codeHeader }
+      ]]
     })
 
     // Remove unwanted newlines (which appear as spaces) from inline tags inside tables

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const liquid = require('./liquid')
+const codeHeader = require('./plugins/code-header')
 const hubdown = require('hubdown')
 const cheerio = require('cheerio')
 const Entities = require('html-entities').XmlEntities
@@ -56,7 +57,8 @@ module.exports = async function renderContent (
 
     let { content: html } = await hubdown(template, {
       // Disable automatic language guessing in syntax highlighting
-      highlight: { subset: false }
+      highlight: { subset: false },
+      runBefore: [codeHeader]
     })
 
     // Remove unwanted newlines (which appear as spaces) from inline tags inside tables

--- a/package-lock.json
+++ b/package-lock.json
@@ -9118,6 +9118,14 @@
         "es6-error": "^4.0.1"
       }
     },
+    "remark-code-extra": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remark-code-extra/-/remark-code-extra-1.0.1.tgz",
+      "integrity": "sha512-MHKTd2zsKc9ayrLBaUzyiIw7rNY4Q/aNSx1L1xss7ZthQ/oSEoMvtA5wpXALVKTWOL5JQXDf/Q9lP8IWbP3cig==",
+      "requires": {
+        "unist-util-visit": "^1.4.1"
+      }
+    },
     "remark-gemoji-to-emoji": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remark-gemoji-to-emoji/-/remark-gemoji-to-emoji-1.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,14 @@
         "@types/node": ">= 8"
       }
     },
+    "@primer/octicons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-11.0.0.tgz",
+      "integrity": "sha512-aMM2n7dl4ToEqQH9ZWQ8M8alGCoGsRk2k5hT5h3KXd54YFKte1twhJDvyQjIjjxqggNh5NUfyuqTOv6MPCVSKQ==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
     "@semantic-release/commit-analyzer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
@@ -664,6 +672,14 @@
         "@types/node": "*"
       }
     },
+    "@types/hast": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+      "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -686,6 +702,11 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -1156,6 +1177,16 @@
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",
         "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
       }
     },
     "chokidar": {
@@ -3154,15 +3185,29 @@
       }
     },
     "hast-util-from-parse5": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
-      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.0.tgz",
+      "integrity": "sha512-3ZYnfKenbbkhhNdmOQqgH10vnvPivTdsOJCri+APn0Kty+nRkDHArnaX9Hiaf8H+Ig+vkNptL+SRY/6RwWJk1Q==",
       "requires": {
-        "ccount": "^1.0.3",
+        "@types/parse5": "^5.0.0",
+        "ccount": "^1.0.0",
         "hastscript": "^5.0.0",
         "property-information": "^5.0.0",
-        "web-namespaces": "^1.1.2",
-        "xtend": "^4.0.1"
+        "vfile": "^4.0.0",
+        "web-namespaces": "^1.0.0"
+      },
+      "dependencies": {
+        "hastscript": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0"
+          }
+        }
       }
     },
     "hast-util-has-property": {
@@ -3195,6 +3240,29 @@
         "zwitch": "^1.0.0"
       },
       "dependencies": {
+        "hast-util-from-parse5": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+          "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+          "requires": {
+            "ccount": "^1.0.3",
+            "hastscript": "^5.0.0",
+            "property-information": "^5.0.0",
+            "web-namespaces": "^1.1.2",
+            "xtend": "^4.0.1"
+          }
+        },
+        "hastscript": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0"
+          }
+        },
         "parse5": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -3252,10 +3320,11 @@
       "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
     },
     "hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
       "requires": {
+        "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
         "hast-util-parse-selector": "^2.0.0",
         "property-information": "^5.0.0",
@@ -8478,12 +8547,9 @@
       }
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "path-exists": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "hubdown": "^2.6.0",
     "liquid": "^5.0.0",
     "parse5": "^6.0.1",
+    "remark-code-extra": "^1.0.1",
     "semver": "^5.7.1",
     "strip-html-comments": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "test:deps": "dependency-check . --missing --no-dev && dependency-check . --unused --no-dev"
   },
   "dependencies": {
+    "@primer/octicons": "^11.0.0",
     "cheerio": "^1.0.0-rc.3",
+    "hast-util-from-parse5": "^6.0.0",
+    "hastscript": "^6.0.0",
     "html-entities": "^1.2.1",
     "hubdown": "^2.6.0",
     "liquid": "^5.0.0",
+    "parse5": "^6.0.1",
     "semver": "^5.7.1",
     "strip-html-comments": "^1.0.0"
   },

--- a/plugins/code-header.js
+++ b/plugins/code-header.js
@@ -77,10 +77,10 @@ const LANGUAGE_MAP = {
  * Adds a bar above code blocks that shows the language and a copy button
  */
 module.exports = function addCodeHeader (node) {
-  const hasCopy = node.lang && node.lang.endsWith('{copy}')
+  const hasCopy = node.lang && node.lang.endsWith('{:copy}')
 
   if (hasCopy && node.lang) {
-    node.lang = node.lang.replace(/\{copy\}$/, '')
+    node.lang = node.lang.replace(/\{:copy\}$/, '')
   } else {
     return
   }

--- a/plugins/code-header.js
+++ b/plugins/code-header.js
@@ -91,7 +91,8 @@ module.exports = function addCodeHeader (node) {
   const btnIconAst = parse5.parse(String(btnIconHtml))
   const btnIcon = fromParse5(btnIconAst, btnIconHtml)
 
-  const header = h('header',
+  const header = h(
+    'header',
     {
       class: [
         'd-flex',
@@ -102,18 +103,26 @@ module.exports = function addCodeHeader (node) {
         'rounded-top-1',
         'border'
       ]
-    }, [
+    },
+    [
       h('span', language),
       h(
         'button',
         {
-          class: ['js-btn-copy', 'btn', 'btn-sm', 'tooltipped', 'tooltipped-nw'],
+          class: [
+            'js-btn-copy',
+            'btn',
+            'btn-sm',
+            'tooltipped',
+            'tooltipped-nw'
+          ],
           'data-clipboard-text': node.value,
           'aria-label': 'Copy code to clipboard'
         },
         btnIcon
       )
-    ])
+    ]
+  )
 
   return {
     before: [header]

--- a/plugins/code-header.js
+++ b/plugins/code-header.js
@@ -73,24 +73,32 @@ const LANGUAGE_MAP = {
   jsx: 'JSX'
 }
 
+const COPY_REGEX = /\{:copy\}$/
+
 /**
  * Adds a bar above code blocks that shows the language and a copy button
  */
 module.exports = function addCodeHeader (node) {
-  const hasCopy = node.lang && node.lang.endsWith('{:copy}')
+  // Check if the language matches `lang{:copy}`
+  const hasCopy = node.lang && COPY_REGEX.test(node.lang)
 
-  if (hasCopy && node.lang) {
-    node.lang = node.lang.replace(/\{:copy\}$/, '')
+  if (hasCopy) {
+    // js{:copy} => js
+    node.lang = node.lang.replace(COPY_REGEX, '')
   } else {
+    // It doesn't have the copy annotation, so don't add the header
     return
   }
 
+  // Display the language using the above map of `{ [shortCode]: language }`
   const language = LANGUAGE_MAP[node.lang] || node.lang || 'Code'
 
   const btnIconHtml = octicons.clippy.toSVG()
   const btnIconAst = parse5.parse(String(btnIconHtml))
   const btnIcon = fromParse5(btnIconAst, btnIconHtml)
 
+  // Need to create the header using Markdown AST utilities, to fit
+  // into the Unified processor ecosystem.
   const header = h(
     'header',
     {

--- a/plugins/code-header.js
+++ b/plugins/code-header.js
@@ -1,0 +1,112 @@
+const h = require('hastscript')
+const octicons = require('@primer/octicons')
+const parse5 = require('parse5')
+const fromParse5 = require('hast-util-from-parse5')
+
+const LANGUAGE_MAP = {
+  asp: 'ASP',
+  aspx: 'ASP',
+  'aspx-vb': 'ASP',
+  as3: 'ActionScript',
+  apache: 'ApacheConf',
+  nasm: 'Assembly',
+  bat: 'Batchfile',
+  'c#': 'C#',
+  csharp: 'C#',
+  c: 'C',
+  'c++': 'C++',
+  cpp: 'C++',
+  chpl: 'Chapel',
+  coffee: 'CoffeeScript',
+  'coffee-script': 'CoffeeScript',
+  cfm: 'ColdFusion',
+  'common-lisp': 'Common Lisp',
+  lisp: 'Common Lisp',
+  dpatch: 'Darcs Patch',
+  dart: 'Dart',
+  elisp: 'Emacs Lisp',
+  emacs: 'Emacs Lisp',
+  'emacs-lisp': 'Emacs Lisp',
+  pot: 'Gettext Catalog',
+  html: 'HTML',
+  xhtml: 'HTML',
+  'html+erb': 'HTML+ERB',
+  erb: 'HTML+ERB',
+  irc: 'IRC log',
+  json: 'JSON',
+  jsp: 'Java Server Pages',
+  java: 'Java',
+  javascript: 'JavaScript',
+  js: 'JavaScript',
+  lhs: 'Literate Haskell',
+  'literate-haskell': 'Literate Haskell',
+  objc: 'Objective-C',
+  openedge: 'OpenEdge ABL',
+  progress: 'OpenEdge ABL',
+  abl: 'OpenEdge ABL',
+  pir: 'Parrot Internal Representation',
+  posh: 'PowerShell',
+  puppet: 'Puppet',
+  'pure-data': 'Pure Data',
+  raw: 'Raw token data',
+  rb: 'Ruby',
+  ruby: 'Ruby',
+  r: 'R',
+  scheme: 'Scheme',
+  bash: 'Shell',
+  sh: 'Shell',
+  shell: 'Shell',
+  zsh: 'Shell',
+  supercollider: 'SuperCollider',
+  tex: 'TeX',
+  ts: 'TypeScript',
+  vim: 'Vim script',
+  viml: 'Vim script',
+  rst: 'reStructuredText',
+  xbm: 'X BitMap',
+  xpm: 'X PixMap',
+  yml: 'YAML',
+
+  // Unofficial languages
+  shellsession: 'Shell',
+  jsx: 'JSX'
+}
+
+/**
+ * Adds a bar above code blocks that shows the language and a copy button
+ */
+module.exports = function addCodeHeader (node) {
+  const language = LANGUAGE_MAP[node.lang] || node.lang || 'Code'
+
+  const btnIconHtml = octicons.clippy.toSVG()
+  const btnIconAst = parse5.parse(String(btnIconHtml))
+  const btnIcon = fromParse5(btnIconAst, btnIconHtml)
+
+  const header = h('header',
+    {
+      class: [
+        'd-flex',
+        'flex-items-center',
+        'flex-justify-between',
+        'p-2',
+        'text-small',
+        'rounded-top-1',
+        'border'
+      ]
+    }, [
+      h('span', language),
+      h(
+        'button',
+        {
+          class: ['js-btn-copy', 'btn', 'btn-sm', 'tooltipped', 'tooltipped-nw'],
+          'data-clipboard-text': node.value,
+          'aria-label': 'Copy code to clipboard'
+        },
+        btnIcon
+      )
+    ])
+
+  return {
+    before: [header]
+  }
+}

--- a/plugins/code-header.js
+++ b/plugins/code-header.js
@@ -65,6 +65,7 @@ const LANGUAGE_MAP = {
   rst: 'reStructuredText',
   xbm: 'X BitMap',
   xpm: 'X PixMap',
+  yaml: 'YAML',
   yml: 'YAML',
 
   // Unofficial languages
@@ -76,6 +77,14 @@ const LANGUAGE_MAP = {
  * Adds a bar above code blocks that shows the language and a copy button
  */
 module.exports = function addCodeHeader (node) {
+  const hasCopy = node.lang && node.lang.endsWith('{copy}')
+
+  if (hasCopy && node.lang) {
+    node.lang = node.lang.replace(/\{copy\}$/, '')
+  } else {
+    return
+  }
+
   const language = LANGUAGE_MAP[node.lang] || node.lang || 'Code'
 
   const btnIconHtml = octicons.clippy.toSVG()

--- a/test/render-content.test.js
+++ b/test/render-content.test.js
@@ -256,4 +256,19 @@ some code
       '<table><thead><tr><th>Webhook event payload</th><th>Activity types</th></tr></thead><tbody><tr><td><a href="/webhooks/event-payloads/#issues"><code>issues</code></a></td><td>- <code>opened</code><br>- <code>edited</code><br>- <code>other</code></td></tr></tbody></table>'
     )
   })
+
+  await t.test(
+    'renders a copy button for code blocks with {:copy} annotation',
+    async t => {
+      const template = nl(`
+\`\`\`js{:copy}
+some code
+\`\`\`\
+    `)
+      const html = await renderContent(template)
+      const $ = cheerio.load(html)
+      const el = $('button.js-btn-copy')
+      t.equal(el.data('clipboard-text'), 'some code')
+    }
+  )
 })


### PR DESCRIPTION
This PR adds a `<header>` to the top of code blocks, by adding a custom Unified plugin (that uses [`remark-code-extra`](https://github.com/s0/remark-code-extra)):

It does this by using `hubdown`'s `runBefore` option, which adds plugins to the start of the Unified processor.
You can add a header to code blocks by adding the `{:copy}` annotation after the code fences:

    ```js{:copy}
    const copyMe = true
    ```

This renders:

| ![image](https://user-images.githubusercontent.com/10660468/95881747-e96c6900-0d46-11eb-9abf-1e8ad16c7646.png) |
| --- |

The un-highlighted text is available as `button.js-btn-copy`'s `data-clipboard-text` attribute. That doesn't do anything on it's own, this has to be paired with some client-side functionality to actually add the text to the user's clipboard.

The syntax of the `{:copy}` annotation is based on [Kramdown](https://kramdown.gettalong.org/), a superset of markdown that was used for Jekyll. I'm not married to this approach, but I find it to be a good heuristic to opt-in code blocks - it's clear in the code and isn't too verbose.

## How you can give feedback

* I'd love thoughts on the design of the header
* The code to build the `button` is really verbose, it uses the same Markdown AST utilities as the Unified processor. But I think its necessary; would love to hear that I'm wrong!