### PR TITLE
feat: npm i liquid@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4039,9 +4039,9 @@
       "dev": true
     },
     "liquid": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/liquid/-/liquid-5.0.0.tgz",
-      "integrity": "sha512-lpoE6D+nLSn4W0SwdV1B2EWX+DXFeroSAFk29+XLyO9Y+/k9yRZ4SyoGQCcAHw9kt/G6D/nJaHlStZbbknpsUg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/liquid/-/liquid-5.1.0.tgz",
+      "integrity": "sha512-bL1FuJSqKsmk4UVTiWnxpyuwR70YOJnV3eSztEVe3MbsHB+f9FsEPaSRM1upVJLxTQyv9A+FP5tZhoQq3S7EWQ==",
       "requires": {
         "strftime": "~0.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hastscript": "^6.0.0",
     "html-entities": "^1.2.1",
     "hubdown": "^2.6.0",
-    "liquid": "^5.0.0",
+    "liquid": "^5.1.0",
     "parse5": "^6.0.1",
     "remark-code-extra": "^1.0.1",
     "semver": "^5.7.1",


### PR DESCRIPTION
Installs the newest version of Liquid, v5.1.0 - see release notes: https://github.com/docs/liquid/releases/tag/v5.1.0

Mainly, this adds the `{% render %}` tag. https://github.com/docs/liquid/issues/114 has usage details, as well as links to [Shopify's official docs on this tag](https://shopify.dev/docs/themes/liquid/reference/tags/theme-tags#render).