### PR TITLE
fix: Updoot Liquid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4039,9 +4039,9 @@
       "dev": true
     },
     "liquid": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/liquid/-/liquid-5.1.0.tgz",
-      "integrity": "sha512-bL1FuJSqKsmk4UVTiWnxpyuwR70YOJnV3eSztEVe3MbsHB+f9FsEPaSRM1upVJLxTQyv9A+FP5tZhoQq3S7EWQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/liquid/-/liquid-5.1.1.tgz",
+      "integrity": "sha512-GbZhB1kgcDR1NE1FXEGtcK1EjMUXe2+ENgRecjs5V3ksZUjzZdC3leff/FoL4E02/9Y9tdoHY1zJ2QMwb5kuuw==",
       "requires": {
         "strftime": "~0.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hastscript": "^6.0.0",
     "html-entities": "^1.2.1",
     "hubdown": "^2.6.0",
-    "liquid": "^5.1.0",
+    "liquid": "^5.1.1",
     "parse5": "^6.0.1",
     "remark-code-extra": "^1.0.1",
     "semver": "^5.7.1",


### PR DESCRIPTION
Updoots Liquid with https://github.com/docs/liquid/pull/115, a small bug-fix for the `render` tag.