### PR TITLE
chore: Archive this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# This repo has been archived.
+
+The code shown here has been moved into the [github/docs](https://github.com/github/docs) repository, to make it easier to use and change.
+
+---
+
 # @github-docs/render-content
 
 Markdown and Liquid rendering pipeline for Node.js


### PR DESCRIPTION
We've moved the code used here into the [github/docs](https://github.com/github/docs) repository to make it easier to change this code in tandem with the core repo. This PR adds a note about that shift in the README. Once its merged, I'll properly archive the repo.